### PR TITLE
fix(console): fix infinite loop in Windows update restart

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Centralized Version Management -->
   <PropertyGroup>
-    <Version>0.17.1</Version>
+    <Version>0.17.2</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/console/host/Services/UpdateService.cs
+++ b/console/host/Services/UpdateService.cs
@@ -164,23 +164,25 @@ public sealed partial class UpdateService
                 var script = string.Join("\r\n",
                     "@echo off",
                     // 기존 프로세스 종료 대기
+                    // findstr /I "lm-supply.exe" 사용: PID 미존재 시 tasklist가 stdout에 출력하는
+                    // "INFO: No tasks are running..." 메시지도 ^[A-Za-z] 패턴에 매칭되어 무한루프 발생하는 버그 수정
                     ":wait",
-                    $"tasklist /FI \"PID eq {currentPid}\" /NH 2>NUL | findstr /R \"^[A-Za-z]\" >NUL",
+                    $"tasklist /FI \"PID eq {currentPid}\" /NH 2>NUL | findstr /I \"lm-supply.exe\" >NUL",
                     "if not errorlevel 1 (timeout /t 1 /nobreak >NUL & goto wait)",
                     // 파일 잠금 해제 대기
                     "timeout /t 1 /nobreak >NUL",
                     // 새 파일 복사 (프로세스 종료 후이므로 잠금 없음)
                     $"xcopy \"{extractDir}\\*\" \"{currentDir}\\\" /s /y /q >NUL",
-                    // 새 프로세스 시작
-                    $"start \"\" \"{currentExePath}\" {userArgs}");
+                    // 새 프로세스 시작 (/D로 작업 디렉토리 명시)
+                    $"start \"\" /D \"{currentDir}\" \"{currentExePath}\" {userArgs}");
                 await File.WriteAllTextAsync(scriptPath, script, ct);
 
                 Process.Start(new ProcessStartInfo
                 {
                     FileName = "cmd.exe",
                     Arguments = $"/c \"{scriptPath}\"",
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
+                    UseShellExecute = true,
+                    WindowStyle = ProcessWindowStyle.Hidden,
                 });
             }
             else


### PR DESCRIPTION
## Summary

- **Root cause**: `tasklist /FI "PID eq {pid}" /NH` outputs `INFO: No tasks are running which match the specified criteria.` to stdout when the PID doesn't exist. The previous `findstr /R "^[A-Za-z]"` pattern matched this INFO message (starts with 'I'), causing the wait loop to never exit — so `xcopy` and `start` were never executed and the new server never launched.
- Fixed `findstr` to use `findstr /I "lm-supply.exe"` which only matches when the process is actually running.
- Changed cmd.exe launch from `UseShellExecute=false, CreateNoWindow=true` → `UseShellExecute=true, WindowStyle=Hidden` for reliable Windows station/desktop access when invoking `start ""` internally.
- Added `/D "{currentDir}"` to the `start` command so the new process runs with the correct working directory.
- Bump version to 0.17.2.

## Test plan

- [ ] Run lm-supply console app and click the update button
- [ ] Verify download, extract, replace steps complete
- [ ] Verify old console window closes and new console window opens automatically
- [ ] Verify browser reloads to the new version without manual intervention